### PR TITLE
Cast variable to string

### DIFF
--- a/src/services/ConfigService.js
+++ b/src/services/ConfigService.js
@@ -134,7 +134,7 @@ class ConfigService {
             }
         }
 
-        projectId = projectId.replace('P', '');
+        projectId = String(projectId).replace('P', '');
         projectId = projectId.trim();
 
         return projectId;
@@ -166,7 +166,7 @@ class ConfigService {
             }
         }
 
-        milestoneId = milestoneId.replace('M', '');
+        milestoneId = String(milestoneId).replace('M', '');
         milestoneId = milestoneId.trim();
 
         return milestoneId;
@@ -197,7 +197,7 @@ class ConfigService {
             }
         }
 
-        runId = runId.replace('R', '');
+        runId = String(runId).replace('R', '');
         runId = runId.trim();
 
         return runId;


### PR DESCRIPTION
Using env approach:
`CYPRESS_TESTRAIL_PROJECT_ID=55`
Throws an error:
```
$ node_modules/.bin/cypress run 
...
Your configFile threw an error from: /var/www/cypress.config.js

The error was thrown while executing your e2e.setupNodeEvents() function:

TypeError: projectId.replace is not a function
    at ConfigService.getProjectId (/var/www/node_modules/cypress-testrail/src/services/ConfigService.js:137:31)
    at new Reporter (/var/www/node_modules/cypress-testrail/src/Reporter.js:25:40)

```
Using console.log we get the numeric value which is the reason for the error. The following changes cast the value into string so .replace() is a valid function.