### PR TITLE
Add .replace to omit commas in the array of case IDs

### DIFF
--- a/src/services/TestCaseParser.js
+++ b/src/services/TestCaseParser.js
@@ -16,7 +16,7 @@ class TestCaseParser {
 
             cases.forEach((singleCase) => {
                 if (singleCase.startsWith('C')) {
-                    singleCase = singleCase.replace('C', '');
+                    singleCase = singleCase.replace('C', '').replace(',', '');
                     foundCases.push(singleCase);
                 }
             });


### PR DESCRIPTION
Commas are being included in some of the case ID strings, causing a 400 response from testrail. I've tested this change on my machine and this fixes the issue.